### PR TITLE
Improve round joint connections

### DIFF
--- a/Outliner.roboFontExt/info.plist
+++ b/Outliner.roboFontExt/info.plist
@@ -30,9 +30,9 @@
 	<key>requiresVersionMinor</key>
 	<string>3</string>
 	<key>timeStamp</key>
-	<real>1331628432.7268109</real>
+	<real>1555352410.361658</real>
 	<key>version</key>
-	<string>1.4.3</string>
+	<string>1.4.4</string>
 	<key>com.robofontmechanic.Mechanic</key>
 	<dict>
 		<key>repository</key>

--- a/Outliner.roboFontExt/lib/outlinePen.py
+++ b/Outliner.roboFontExt/lib/outlinePen.py
@@ -129,6 +129,8 @@ class MathPoint(object):
             return self.__class__(self.x / p, self.y / p)
         return self.__class__(self.x / p.x, self.y / p.y)
 
+    __truediv__ = __div__
+
     def __eq__(self, p):  # if p == p
         if not isinstance(p, self.__class__):
             return False
@@ -517,25 +519,25 @@ class OutlinePen(BasePen):
         angle_1 = radians(degrees(self.prevAngle)+90)
         angle_2 = radians(degrees(self.currentAngle)+90)
 
-        tempFirst = first - self.pointClass(cos(angle_1), sin(angle_1)) * self.miterLimit
-        tempLast = last + self.pointClass(cos(angle_2), sin(angle_2)) * self.miterLimit
+        tempFirst = first - self.pointClass(sin(angle_1), -cos(angle_1))
+        tempLast = last + self.pointClass(sin(angle_2), -cos(angle_2))
 
-        newPoint = interSect((first, tempFirst), (last, tempLast))
-        if newPoint is None:
-            pen.lineTo(last)
-            return
-        distance1 = newPoint.distance(first)
-        distance2 = newPoint.distance(last)
-        if roundFloat(distance1) > self.miterLimit + self.contrast:
-            distance1 = self.miterLimit + tempFirst.distance(tempLast) * .7
-        if roundFloat(distance2) > self.miterLimit + self.contrast:
-            distance2 = self.miterLimit + tempFirst.distance(tempLast) * .7
+        centerPoint = interSect((first, tempFirst), (last, tempLast))
+        if centerPoint is None:
+            # the lines are parallel, let's just take the middle
+            centerPoint = (first + last) / 2
 
-        distance1 *= self.magicCurve
-        distance2 *= self.magicCurve
+        angle_diff = (angle_1 - angle_2) % (2 * pi)
+        if angle_diff > pi:
+            angle_diff = 2 * pi - angle_diff
+        angle_half = angle_diff / 2
 
-        bcp1 = first - self.pointClass(cos(angle_1), sin(angle_1)) * distance1
-        bcp2 = last + self.pointClass(cos(angle_2), sin(angle_2)) * distance2
+        radius = centerPoint.distance(first)
+        D = radius * (1 - cos(angle_half))
+        handleLength = (4 * D / 3) / sin(angle_half)  # length of the bcp line
+
+        bcp1 = first - self.pointClass(cos(angle_1), sin(angle_1)) * handleLength
+        bcp2 = last + self.pointClass(cos(angle_2), sin(angle_2)) * handleLength
         pen.curveTo(bcp1, bcp2, last)
 
     def connectionButt(self, first, last, pen, close):
@@ -577,7 +579,7 @@ class OutlinePen(BasePen):
 
         oncurve = p1 + (p2 - p1) * .5
 
-        roundness = .54
+        roundness = .54  # should be self.magicCurve
 
         h1 = first - self.pointClass(cos(hookedAngle), sin(hookedAngle)) * self.offset * roundness
         h2 = oncurve + self.pointClass(cos(angle), sin(angle)) * self.offset * roundness


### PR DESCRIPTION
- The magicCurve constant (0.55228...) is only valid for 90 degree angles. The new code calculates the right factor
- Make MathPoint()/N work on Py 3
- Bump timestamp and version